### PR TITLE
Fixed internal linking of FAQs

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
         />
       </div>
     </section>
-    <section class="sec-5 flex">
+    <section class="sec-5 flex" id="faqs">
       <h1 style="text-align: center; font-size: 3.2rem">
         Frequently Asked Questions
       </h1>
@@ -172,6 +172,8 @@
         </div>
       </div>
     </section>
+
+
     <footer class="flex">
       <div class="div flex">
         <p>Questions?Call <a href="tel:tel:000-8">000-800-040-1843</a></p>
@@ -179,7 +181,7 @@
       <div class="all-items flex">
         <div class="ul-1 flex">
           <ul>
-            <li><a href="">FAQ</a></li>
+            <li><a href="#faqs">FAQ</a></li>
             <li><a href="">Investor Relation</a></li>
             <li><a href="">Privacy</a></li>
             <li><a href="">Spedd Test</a></li>


### PR DESCRIPTION
 When someone click on FAQs on the footer, they will go to the FAQs section directly . Initially, there was no linking.